### PR TITLE
allow nested events for autocommands

### DIFF
--- a/lua/auspicious-autosave.lua
+++ b/lua/auspicious-autosave.lua
@@ -55,6 +55,7 @@ function M.setup()
     vim.api.nvim_create_autocmd(events, {
         desc = "autosave",
         callback = callback,
+        nested = true, -- otherwise we dont trigger BufWrite
     })
 end
 


### PR DESCRIPTION
Without the nesting option, autosave behaves differently from :w as it doesn't trigger the BufWrite event. (see: https://neovim.io/doc/user/autocmd.html#autocmd-nested).